### PR TITLE
Add Codex-style theming to landing pages

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,251 @@
+:root {
+  --color-bg-start: #0f172a;
+  --color-bg-end: #111827;
+  --color-surface: rgba(15, 23, 42, 0.75);
+  --color-surface-solid: #1f2937;
+  --color-primary: #3b82f6;
+  --color-primary-dark: #2563eb;
+  --color-text: #e2e8f0;
+  --color-muted: #94a3b8;
+  --shadow-soft: 0 20px 45px rgba(15, 23, 42, 0.45);
+  --radius-lg: 20px;
+  --radius-md: 14px;
+  --transition: 200ms ease;
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  font-family: "Pretendard", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--color-text);
+  background: radial-gradient(circle at 20% 20%, rgba(59, 130, 246, 0.35), transparent 55%),
+    radial-gradient(circle at 80% 10%, rgba(129, 140, 248, 0.25), transparent 50%),
+    linear-gradient(160deg, var(--color-bg-start), var(--color-bg-end));
+  min-height: 100vh;
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  color: var(--color-primary);
+}
+
+header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: linear-gradient(180deg, rgba(17, 24, 39, 0.85), rgba(17, 24, 39, 0.6));
+  backdrop-filter: blur(16px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.container {
+  width: min(1120px, 92vw);
+  margin: 0 auto;
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 0;
+  gap: 24px;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 600;
+  font-size: 1.05rem;
+  letter-spacing: 0.02em;
+}
+
+.brand .logo {
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.95), rgba(14, 165, 233, 0.85));
+  box-shadow: 0 10px 25px rgba(59, 130, 246, 0.45);
+  display: inline-block;
+}
+
+nav ul {
+  display: flex;
+  gap: 20px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+nav a {
+  font-size: 0.95rem;
+  color: var(--color-muted);
+  padding: 8px 0;
+  position: relative;
+  transition: color var(--transition);
+}
+
+nav a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -6px;
+  height: 2px;
+  transform: scaleX(0);
+  transform-origin: center;
+  background: linear-gradient(90deg, rgba(59, 130, 246, 0.2), rgba(59, 130, 246, 0.9));
+  transition: transform var(--transition);
+}
+
+nav a:hover,
+nav a:focus {
+  color: var(--color-text);
+}
+
+nav a:hover::after,
+nav a:focus::after {
+  transform: scaleX(1);
+}
+
+main {
+  padding: 56px 0 80px;
+}
+
+h1,
+h2,
+h3 {
+  font-family: "Pretendard", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-weight: 600;
+  line-height: 1.3;
+  margin-top: 0;
+  color: #f8fafc;
+}
+
+p {
+  margin-top: 0.5em;
+  margin-bottom: 1.25em;
+  color: var(--color-muted);
+}
+
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 24px;
+  margin-top: 32px;
+}
+
+.card {
+  display: block;
+  background: rgba(30, 41, 59, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.08);
+  border-radius: var(--radius-lg);
+  padding: 28px;
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(10px);
+  transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition);
+}
+
+.card h3 {
+  margin-bottom: 12px;
+}
+
+.card:hover,
+.card:focus {
+  transform: translateY(-6px);
+  box-shadow: 0 24px 55px rgba(15, 23, 42, 0.55);
+  border-color: rgba(59, 130, 246, 0.35);
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 22px;
+  border-radius: var(--radius-md);
+  border: none;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform var(--transition), box-shadow var(--transition), background var(--transition), border-color var(--transition);
+}
+
+.btn.primary {
+  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-dark));
+  color: white;
+  box-shadow: 0 15px 35px rgba(37, 99, 235, 0.35);
+}
+
+.btn.primary:hover,
+.btn.primary:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 40px rgba(37, 99, 235, 0.45);
+}
+
+.btn.ghost {
+  background: transparent;
+  color: var(--color-primary);
+  border: 1.5px solid rgba(59, 130, 246, 0.65);
+  box-shadow: none;
+}
+
+.btn.ghost:hover,
+.btn.ghost:focus {
+  border-color: rgba(59, 130, 246, 1);
+  color: #bfdbfe;
+  transform: translateY(-2px);
+}
+
+footer {
+  padding: 28px 0 48px;
+  color: rgba(148, 163, 184, 0.7);
+  font-size: 0.85rem;
+}
+
+footer .container {
+  text-align: center;
+}
+
+@media (max-width: 768px) {
+  .nav {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 14px;
+  }
+
+  nav ul {
+    width: 100%;
+    justify-content: flex-start;
+    gap: 16px;
+  }
+
+  main {
+    padding-top: 48px;
+  }
+}
+
+@media (max-width: 480px) {
+  .brand {
+    font-size: 1rem;
+  }
+
+  .card {
+    padding: 22px;
+  }
+
+  .btn {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- add a Codex-inspired dark theme with blue accents and gradient background
- style navigation, cards, and buttons for a cohesive card-based layout
- implement responsive grid and typography updates shared across pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de2a973174832aa1d7d580e99da4b7