### PR TITLE
feat: apply modern dark theme styling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,196 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+:root {
+  --bg-color: #05060a;
+  --surface-color: #0f111a;
+  --surface-elevated: rgba(30, 35, 54, 0.9);
+  --border-color: rgba(148, 163, 184, 0.1);
+  --text-color: #e2e8f0;
+  --muted-color: #94a3b8;
+  --accent-gradient: linear-gradient(135deg, #4f46e5, #22d3ee);
+  --accent-color: #22d3ee;
+  --shadow-color: rgba(15, 23, 42, 0.6);
+  --transition: 200ms ease;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  font-family: 'Inter', sans-serif;
+  background: radial-gradient(circle at top, rgba(79, 70, 229, 0.18), transparent 55%), var(--bg-color);
+  color: var(--text-color);
+  min-height: 100%;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover {
+  color: var(--accent-color);
+}
+
+.container {
+  width: min(1100px, calc(100% - 48px));
+  margin: 0 auto;
+}
+
+header {
+  position: fixed;
+  inset: 0 0 auto 0;
+  background: rgba(5, 6, 10, 0.7);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--border-color);
+  z-index: 10;
+}
+
+header .nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 0;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.brand .logo {
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
+  background: var(--accent-gradient);
+  box-shadow: 0 12px 30px rgba(34, 211, 238, 0.3);
+}
+
+nav ul {
+  list-style: none;
+  display: flex;
+  gap: 28px;
+  margin: 0;
+  padding: 0;
+}
+
+nav a {
+  font-weight: 500;
+  font-size: 0.95rem;
+  color: var(--muted-color);
+  transition: color var(--transition);
+}
+
+nav a:hover,
+nav a:focus {
+  color: var(--text-color);
+}
+
+main {
+  flex: 1;
+  padding: 120px 0 80px;
+}
+
+main h1 {
+  font-size: clamp(2.5rem, 3vw + 1rem, 3.5rem);
+  margin-bottom: 12px;
+  line-height: 1.1;
+  background: var(--accent-gradient);
+  -webkit-background-clip: text;
+  color: transparent;
+}
+
+main p {
+  font-size: 1.05rem;
+  color: var(--muted-color);
+  margin-bottom: 32px;
+}
+
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 28px;
+}
+
+.card {
+  display: block;
+  background: var(--surface-elevated);
+  border: 1px solid var(--border-color);
+  border-radius: 18px;
+  padding: 28px;
+  box-shadow: 0 18px 40px -24px var(--shadow-color);
+  transition: transform var(--transition), border-color var(--transition), box-shadow var(--transition);
+}
+
+.card:hover,
+.card:focus-visible {
+  transform: translateY(-6px);
+  border-color: rgba(79, 70, 229, 0.6);
+  box-shadow: 0 24px 50px -22px rgba(15, 23, 42, 0.75);
+}
+
+.card h3 {
+  margin: 0 0 12px;
+  font-size: 1.45rem;
+  font-weight: 600;
+  background: var(--accent-gradient);
+  -webkit-background-clip: text;
+  color: transparent;
+}
+
+.card p {
+  margin: 0;
+  color: var(--muted-color);
+  line-height: 1.6;
+}
+
+footer {
+  background: rgba(4, 5, 9, 0.95);
+  border-top: 1px solid var(--border-color);
+  padding: 32px 0;
+  font-size: 0.8rem;
+  color: var(--muted-color);
+}
+
+footer .container {
+  text-align: center;
+}
+
+@media (max-width: 900px) {
+  nav ul {
+    gap: 18px;
+  }
+
+  .grid-3 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  header .nav {
+    padding: 16px 0;
+  }
+
+  .grid-3 {
+    grid-template-columns: 1fr;
+  }
+
+  main {
+    padding: 110px 0 60px;
+  }
+
+  .card {
+    padding: 24px;
+  }
+}


### PR DESCRIPTION
## Summary
- create a shared stylesheet with an Inter-based modern dark theme
- add fixed navigation bar, gradient hero typography, and responsive card grid
- refine card and footer styling to match the Codex-inspired look

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de2d07a298832aa9f0c2723407bcec